### PR TITLE
Fix interest remaining_amount tracking bug

### DIFF
--- a/data_parser.py
+++ b/data_parser.py
@@ -460,7 +460,7 @@ class DataParser:
         dividend_per_capital = remaining_amount/total_capital
         for (month,capital) in month_capital:
                 self.data_cur.execute("UPDATE month_data SET capital = capital + ? WHERE month = ?",(capital*dividend_per_capital,month))
-                remaining_amount -= capital
+                remaining_amount -= capital*dividend_per_capital
         if remaining_amount > 0:
             self.data_cur.execute("UPDATE month_data SET capital = capital + ? WHERE month = ?",(remaining_amount,dividend_month))
         # Reset transaction_cur since new funds are available


### PR DESCRIPTION
## Summary

Fixes a bug in  where  should be .

## The Bug

In , line 463:


Should be:


## Impact

The bug caused  to become very negative instead of tracking the actual distributed interest amount. This prevented microscopic floating-point rounding errors (on the order of 10^-14 SEK) from being added to .

## Testing

Tested with complete transaction history:
- Before fix: Microscopic rounding errors were lost
- After fix: Microscopic amounts (e.g., 1.47e-14 SEK) are properly distributed to appropriate months
- No observable change in monthly statistics (amounts are too small)
- Total capital remains identical

## Why No Tests

The fix handles edge-case floating-point rounding that's difficult to test reliably with CSV integration tests. The amounts involved are sub-atomic (10^-14 SEK vs öre = 10^-2 SEK) and don't affect practical calculations.