### PR TITLE
Fix Python 3.12 compatibility warnings

### DIFF
--- a/data_parser.py
+++ b/data_parser.py
@@ -57,9 +57,8 @@ class SpecialCases:
         file_path (str): Path to json file containing special cases.
         """
         # Read special cases from json file
-        special_cases_file = open(file_path, "r")
-        special_cases = json.load(special_cases_file)
-        special_cases_file.close()
+        with open(file_path, "r") as special_cases_file:
+            special_cases = json.load(special_cases_file)
 
         # Define a mapping from operator strings to functions
         ops = {
@@ -191,12 +190,12 @@ class DataParser:
         int: Number of rows added to the database.
         """
         # file_path = ./data/newdata.csv
-        avanza_data_file = open(file_path,"r")
-        avanza_data = csv.reader(avanza_data_file, delimiter=';')
-        # Detect CSV format version from header row
-        avanza_header_row = next(avanza_data)
-        new_format = "Transaktionsvaluta" in avanza_header_row
-        avanza_data = list(avanza_data)
+        with open(file_path, "r") as avanza_data_file:
+            avanza_data = csv.reader(avanza_data_file, delimiter=';')
+            # Detect CSV format version from header row
+            avanza_header_row = next(avanza_data)
+            new_format = "Transaktionsvaluta" in avanza_header_row
+            avanza_data = list(avanza_data)
 
         # Find overlapping transactions to avoid adding douplicates
         max_date = max([datetime.strptime(row[0],"%Y-%m-%d") for row in avanza_data]).date()

--- a/database_handler.py
+++ b/database_handler.py
@@ -1,4 +1,17 @@
 import sqlite3
+from datetime import date
+
+def adapt_date(val):
+    """Convert datetime.date to ISO format string."""
+    return val.isoformat()
+
+def convert_date(val):
+    """Convert ISO format string to datetime.date."""
+    return date.fromisoformat(val.decode() if isinstance(val, bytes) else val)
+
+# Register the adapter and converter
+sqlite3.register_adapter(date, adapt_date)
+sqlite3.register_converter("date", convert_date)
 
 class DatabaseHandler:
     """


### PR DESCRIPTION
## Summary

Fixes Python 3.12 compatibility warnings in the test suite:

1. **sqlite3 date adapter/converter deprecation warnings** (749 warnings!)
   - Python 3.12 deprecated default date adapters/converters
   - Added explicit adapters and converters for  objects
   - Registered with  and 

2. **ResourceWarnings for unclosed files**
   - Replaced  without context managers with  
   - Ensures files are properly closed even on exceptions

## Changes

### 
- Added  and  functions
- Registered adapters/converters for  type
- Required for Python 3.12 sqlite3 compatibility

### 
- : Use context manager for CSV file
- : Use context manager for JSON file
- Both methods now properly close files

## Testing

All tests pass with  (treat warnings as errors):
- No deprecation warnings
- No resource warnings  
- 23 passed, 4 skipped, 1 xfailed

## Impact

- Eliminates 749 deprecation warnings from test output
- Future-proof for Python 3.12+ compatibility
- Cleaner resource management with context managers