### PR TITLE
Fix per-account mode: internal transfers, transaction ordering, complex number crash

### DIFF
--- a/calculate_stats.py
+++ b/calculate_stats.py
@@ -62,7 +62,8 @@ class StatCalculator:
 
             middle_date = month.replace(day=15)
             if today >= middle_date + timedelta(365.25) and total_gainloss_per !=0:
-                annual_per_yield = 100*((total_gainloss_per/100+1)**(1/((datetime.today().date()-middle_date).days/365.25))-1)
+                base = total_gainloss_per/100+1
+                annual_per_yield = 100*(base**(1/((datetime.today().date()-middle_date).days/365.25))-1) if base > 0 else None
             else:
                 annual_per_yield = None
 
@@ -138,7 +139,8 @@ class StatCalculator:
 
             middle_date = datetime(year=year.year,month=7,day=1).date()
             if datetime.today().date() >= middle_date + timedelta(365.25) and total_gainloss_per !=0:
-                annual_per_yield = 100*((total_gainloss_per/100+1)**(1/((datetime.today().date()-middle_date).days/365.25))-1)
+                base = total_gainloss_per/100+1
+                annual_per_yield = 100*(base**(1/((datetime.today().date()-middle_date).days/365.25))-1) if base > 0 else None
             else:
                 annual_per_yield = None
 

--- a/data_parser.py
+++ b/data_parser.py
@@ -24,7 +24,7 @@ class AssetDeficit(Exception):
         super().__init__(message)
         self.data_parser = data_parser
         logging.error(message)
-        data_parser.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, rowid ASC")
+        data_parser.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, CASE WHEN transaction_type IN ('Insättning', 'Intern överföring') THEN 0 ELSE 1 END ASC, rowid ASC")
         logging.error("Unprocessed transactions:")
         for row in data_parser.transaction_cur.fetchall():
             logging.error(row)
@@ -123,21 +123,23 @@ class SpecialCases:
                 row = self.special_cases[i][1](row)
         return row
 
-# TODO: The DataParser does not check which account the transaction is made from, consider implementing this
-
 class DataParser:
     """
     DataParser class handles the processing of transactions in the database.
     """
-    def __init__(self, db: DatabaseHandler, special_cases: SpecialCases = None):
+    def __init__(self, db: DatabaseHandler, special_cases: SpecialCases = None, per_account: bool = False):
         """
         Parameters:
         database (DatabaseHandler): The database to add data to.
         special_cases (SpecialCases): SpecialCases object that handles special rules when adding data to the database.
+        per_account (bool): If True, track capital per account instead of globally. Each account's
+            capital is managed independently with FIFO applied within each account. This ensures
+            that e.g. savings account interest is not counted as realized gain in investment accounts.
         """
         self.listing_change = {"to_asset":None,"to_asset_amount":None,"to_rowid":None}
         self.db = db
         self.special_cases = special_cases
+        self.per_account = per_account
         # Two cursors are used, one for handling writing processed lines and one responsible for keeping track of unprocessed lines
         self._data_cur = None
         self._transaction_cur = None
@@ -257,6 +259,8 @@ class DataParser:
         self.db.reset_table("month_data")
         self.db.reset_table("month_assets")
         self.db.reset_table("assets")
+        if "month_account_data" in self.db.tables:
+            self.db.reset_table("month_account_data")
         self.db.commit()
 
     def allocate_to_month(self, transaction_date: date) -> date:
@@ -298,6 +302,23 @@ class DataParser:
         else:
             return [(None,0)]
 
+    def available_capital_for_account(self, account: str) -> list:
+        """
+        Get available capital for a specific account, used in per-account mode.
+        Returns list of (month, capital) tuples ordered oldest first.
+
+        Parameters:
+        account (str): Account name to get capital for.
+
+        Returns:
+        list: List of (month, capital) tuples with capital > 0 for that account.
+        """
+        res = self.data_cur.execute(
+            "SELECT month, capital FROM month_account_data WHERE account = ? AND capital > 0 ORDER BY month ASC",
+            (account,)
+        ).fetchall()
+        return res if res else [(None, 0)]
+
     def available_asset(self, asset_id: int) -> list:
         """
         Get available assets for each recorded month. If there is no recorded month, return (None,0).
@@ -323,22 +344,28 @@ class DataParser:
         """
         month = self.allocate_to_month(row[0])
         amount = row[6]
+        account = row[1]
         self.data_cur.execute("UPDATE month_data SET capital = capital + ?, deposit = deposit + ? WHERE month = ?",(amount,amount,month))
+        if self.per_account:
+            self.data_cur.execute("INSERT OR IGNORE INTO month_account_data(month, account) VALUES(?,?)", (month, account))
+            self.data_cur.execute("UPDATE month_account_data SET capital = capital + ?, deposit = deposit + ? WHERE month = ? AND account = ?", (amount, amount, month, account))
         # Reset transaction_cur since new funds are available
         self.transaction_cur.execute("UPDATE transactions SET processed = 1 WHERE rowid = ?",(row[-1],))
-        self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, rowid ASC")
+        self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, CASE WHEN transaction_type IN ('Insättning', 'Intern överföring') THEN 0 ELSE 1 END ASC, rowid ASC")
 
     def handle_withdrawal(self, row: tuple) -> None:
         """
         Takes a transaction row and subtracts the amount from the capital of the oldest month(s) with available capital.
         If there is not enough total capital available, the transaction is not processed.
+        In per-account mode, only uses capital from the same account.
 
         Parameters:
         row (tuple): A row from the transactions table in the database.
         """
         total_amount = -row[6]
         remaining_amount = total_amount
-        month_capital = self.available_capital()
+        account = row[1]
+        month_capital = self.available_capital_for_account(account) if self.per_account else self.available_capital()
         total_capital = sum(e[1] for e in month_capital)
         if total_capital + 1e-4 >= total_amount:
             i = 0
@@ -346,28 +373,32 @@ class DataParser:
                 (oldest_available,capital) = month_capital[i]
                 month_amount = min(remaining_amount,capital)
                 self.data_cur.execute("UPDATE month_data SET capital = capital - ?, withdrawal = withdrawal + ? WHERE month = ?",(month_amount,month_amount,oldest_available))
+                if self.per_account:
+                    self.data_cur.execute("UPDATE month_account_data SET capital = capital - ?, withdrawal = withdrawal + ? WHERE month = ? AND account = ?", (month_amount, month_amount, oldest_available, account))
                 remaining_amount -= month_amount
                 i += 1
             self.transaction_cur.execute("UPDATE transactions SET processed = 1 WHERE rowid = ?",(row[-1],))
-            self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, rowid ASC")
+            self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, CASE WHEN transaction_type IN ('Insättning', 'Intern överföring') THEN 0 ELSE 1 END ASC, rowid ASC")
 
     def handle_purchase(self, row: tuple) -> None: 
         """
         Takes a transaction row and subtracts the purchase amount from the capital of the oldest month(s) with available capital.
         Then allocates a proportional amount of the asset to those months.
         If there is not enough total capital available, the transaction is not processed.
+        In per-account mode, only uses capital from the same account.
 
         Parameters:
         row (tuple): A row from the transactions table in the database.
         """
         asset = row[3]
+        account = row[1]
         self.data_cur.execute("INSERT OR IGNORE INTO assets (asset) VALUES (?) ",(asset,))
         asset_id = self.data_cur.execute("SELECT asset_id FROM assets WHERE asset = ?",(asset,)).fetchone()[0]
         asset_amount = row[4]
         price = row[5]
         total_amount = -row[6]
         remaining_amount = total_amount
-        month_capital = self.available_capital()
+        month_capital = self.available_capital_for_account(account) if self.per_account else self.available_capital()
         total_capital = sum(e[1] for e in month_capital)
         if total_capital + 1e-3 >= total_amount:
             i = 0
@@ -376,6 +407,8 @@ class DataParser:
                 month_amount = min(remaining_amount,capital)
                 month_asset_amount = month_amount / total_amount * asset_amount
                 self.data_cur.execute("UPDATE month_data SET capital = capital - ? WHERE month = ?",(month_amount,oldest_available))
+                if self.per_account:
+                    self.data_cur.execute("UPDATE month_account_data SET capital = capital - ? WHERE month = ? AND account = ?", (month_amount, oldest_available, account))
                 self.data_cur.execute("INSERT OR IGNORE INTO month_assets(month,asset_id) VALUES (?,?)",(oldest_available,asset_id))
                 self.data_cur.execute("UPDATE month_assets SET average_price = ?/(amount+?)*?+amount/(amount+?)*average_price WHERE month = ? AND asset_id = ?",(month_amount,month_amount,price,month_amount,oldest_available,asset_id))
                 self.data_cur.execute("UPDATE month_assets SET average_purchase_price = ?/(purchased_amount+?)*?+purchased_amount/(purchased_amount+?)*average_purchase_price WHERE month = ? AND asset_id = ?",(month_amount,month_amount,price,month_amount,oldest_available,asset_id))
@@ -384,18 +417,20 @@ class DataParser:
                 i += 1
             # Reset transaction_cur since new assets are available
             self.transaction_cur.execute("UPDATE transactions SET processed = 1 WHERE rowid = ?",(row[-1],))
-            self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, rowid ASC")
+            self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, CASE WHEN transaction_type IN ('Insättning', 'Intern överföring') THEN 0 ELSE 1 END ASC, rowid ASC")
  
     def handle_sale(self, row: tuple) -> None:
         """
         Takes a transaction row and subtracts the sale asset amount from the oldest month(s) with that available asset.
         Then adds the sale amount to the capital of those months.
         If there is not enough total assets available, the transaction is not processed.
+        In per-account mode, sale proceeds are returned to the selling account's capital for those months.
 
         Parameters:
         row (tuple): A row from the transactions table in the database.
         """
         asset = row[3]
+        account = row[1]
         self.data_cur.execute("INSERT OR IGNORE INTO assets (asset) VALUES (?) ",(asset,))
         asset_id = self.data_cur.execute("SELECT asset_id FROM assets WHERE asset = ?",(asset,)).fetchone()[0]
         asset_amount = -row[4]
@@ -413,11 +448,14 @@ class DataParser:
                 self.data_cur.execute("UPDATE month_assets SET average_sale_price = ?/(sold_amount+?)*?+sold_amount/(sold_amount+?)*average_sale_price WHERE month = ? AND asset_id = ?",(month_amount,month_amount,price,month_amount,oldest_available,asset_id))
                 self.data_cur.execute("UPDATE month_assets SET amount = amount - ?, sold_amount = sold_amount + ? WHERE month = ? AND asset_id = ?",(month_amount, month_amount, oldest_available,asset_id))
                 self.data_cur.execute("UPDATE month_data SET capital = capital + ? WHERE month = ?",(month_capital_amount,oldest_available))
+                if self.per_account:
+                    self.data_cur.execute("INSERT OR IGNORE INTO month_account_data(month, account) VALUES(?,?)", (oldest_available, account))
+                    self.data_cur.execute("UPDATE month_account_data SET capital = capital + ? WHERE month = ? AND account = ?", (month_capital_amount, oldest_available, account))
                 remaining_amount -= month_amount
                 i += 1
             # Reset transaction_cur since new funds are available
             self.transaction_cur.execute("UPDATE transactions SET processed = 1 WHERE rowid = ?",(row[-1],))
-            self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, rowid ASC")
+            self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, CASE WHEN transaction_type IN ('Insättning', 'Intern överföring') THEN 0 ELSE 1 END ASC, rowid ASC")
 
     def handle_dividend(self, row: tuple) -> None:
         """
@@ -443,40 +481,52 @@ class DataParser:
             self.data_cur.execute("UPDATE month_data SET capital = capital + ? WHERE month = ?",(remaining_amount*dividend_per_asset,dividend_month))
         # Reset transaction_cur since new funds are available
         self.transaction_cur.execute("UPDATE transactions SET processed = 1 WHERE rowid = ?",(row[-1],))
-        self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, rowid ASC")
+        self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, CASE WHEN transaction_type IN ('Insättning', 'Intern överföring') THEN 0 ELSE 1 END ASC, rowid ASC")
 
     def handle_interest(self, row: tuple) -> None:
         """
-        Takes a transaction row and adds the dividend amount proporionally to the capital of all the month(s) with that available capital.
+        Takes a transaction row and adds the interest amount proportionally to the capital of all month(s) with available capital.
+        In per-account mode, distributes only within the account's own capital, so savings account
+        interest stays attributed to savings account months (not leaked to investment account months).
 
         Parameters:
         row (tuple): A row from the transactions table in the database.
         """
         dividend_month = self.allocate_to_month(row[0])
+        account = row[1]
         remaining_amount = row[6]
-        month_capital = self.available_capital()
+        month_capital = self.available_capital_for_account(account) if self.per_account else self.available_capital()
         total_capital = sum([month[1] for month in month_capital])
-        dividend_per_capital = remaining_amount/total_capital
-        for (month,capital) in month_capital:
-                self.data_cur.execute("UPDATE month_data SET capital = capital + ? WHERE month = ?",(capital*dividend_per_capital,month))
-                remaining_amount -= capital*dividend_per_capital
+        dividend_per_capital = remaining_amount / total_capital
+        for (month, capital) in month_capital:
+            amount_added = capital * dividend_per_capital
+            self.data_cur.execute("UPDATE month_data SET capital = capital + ? WHERE month = ?", (amount_added, month))
+            if self.per_account:
+                self.data_cur.execute("INSERT OR IGNORE INTO month_account_data(month, account) VALUES(?,?)", (month, account))
+                self.data_cur.execute("UPDATE month_account_data SET capital = capital + ? WHERE month = ? AND account = ?", (amount_added, month, account))
+            remaining_amount -= amount_added
         if remaining_amount > 0:
-            self.data_cur.execute("UPDATE month_data SET capital = capital + ? WHERE month = ?",(remaining_amount,dividend_month))
+            self.data_cur.execute("UPDATE month_data SET capital = capital + ? WHERE month = ?", (remaining_amount, dividend_month))
+            if self.per_account:
+                self.data_cur.execute("INSERT OR IGNORE INTO month_account_data(month, account) VALUES(?,?)", (dividend_month, account))
+                self.data_cur.execute("UPDATE month_account_data SET capital = capital + ? WHERE month = ? AND account = ?", (remaining_amount, dividend_month, account))
         # Reset transaction_cur since new funds are available
         self.transaction_cur.execute("UPDATE transactions SET processed = 1 WHERE rowid = ?",(row[-1],))
-        self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, rowid ASC")
+        self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, CASE WHEN transaction_type IN ('Insättning', 'Intern överföring') THEN 0 ELSE 1 END ASC, rowid ASC")
 
     def handle_fees(self, row: tuple) -> None:
         """
         Takes a transaction row and subtracts the fee amount from the capital of the oldest month(s) with available capital.
         If there is not enough total capital available, the transaction is not processed.
+        In per-account mode, only uses capital from the same account.
 
         Parameters:
         row (tuple): A row from the transactions table in the database.
         """
         total_amount = -row[6]
         remaining_amount = total_amount
-        month_capital = self.available_capital()
+        account = row[1]
+        month_capital = self.available_capital_for_account(account) if self.per_account else self.available_capital()
         total_capital = sum(e[1] for e in month_capital)
         if total_capital + 1e-4 >= total_amount:
             i = 0
@@ -484,10 +534,12 @@ class DataParser:
                 (oldest_available,capital) = month_capital[i]
                 month_amount = min(remaining_amount,capital)
                 self.data_cur.execute("UPDATE month_data SET capital = capital - ? WHERE month = ?",(month_amount,oldest_available))
+                if self.per_account:
+                    self.data_cur.execute("UPDATE month_account_data SET capital = capital - ? WHERE month = ? AND account = ?", (month_amount, oldest_available, account))
                 remaining_amount -= month_amount
                 i += 1
             self.transaction_cur.execute("UPDATE transactions SET processed = 1 WHERE rowid = ?",(row[-1],))
-            self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, rowid ASC")
+            self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, CASE WHEN transaction_type IN ('Insättning', 'Intern överföring') THEN 0 ELSE 1 END ASC, rowid ASC")
 
     def handle_listing_change(self, row: tuple) -> None:
         """
@@ -510,7 +562,7 @@ class DataParser:
             change_factor = self.listing_change["to_asset_amount"]/amount
             self.data_cur.execute("UPDATE month_assets SET amount = amount * ? WHERE asset_id = ?",(change_factor,asset_id))
             self.transaction_cur.execute("UPDATE transactions SET processed = 1 WHERE rowid = ? OR rowid = ?",(row[-1],self.listing_change["to_rowid"],))
-            self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, rowid ASC")
+            self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, CASE WHEN transaction_type IN ('Insättning', 'Intern överföring') THEN 0 ELSE 1 END ASC, rowid ASC")
             self.listing_change = {"to_asset":None,"to_asset_amount":None,"to_rowid":None}
     
     def handle_asset_deposit(self, row: tuple) -> None:
@@ -536,7 +588,7 @@ class DataParser:
         self.data_cur.execute("UPDATE month_data SET deposit = deposit + ? WHERE month = ?",(amount*price,month))
         # Reset transaction_cur since new assets are available
         self.transaction_cur.execute("UPDATE transactions SET processed = 1 WHERE rowid = ?",(row[-1],))
-        self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, rowid ASC")
+        self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, CASE WHEN transaction_type IN ('Insättning', 'Intern överföring') THEN 0 ELSE 1 END ASC, rowid ASC")
 
     def handle_ignore(self, row: tuple) -> None:
         """
@@ -548,7 +600,65 @@ class DataParser:
         """
         logging.debug(f"Ignoring transaction {row[0]} {row[2]} {row[3]} with amount {row[6]}")
         self.transaction_cur.execute("UPDATE transactions SET processed = 1 WHERE rowid = ?", (row[-1],))
-        self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, rowid ASC")
+        self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, CASE WHEN transaction_type IN ('Insättning', 'Intern överföring') THEN 0 ELSE 1 END ASC, rowid ASC")
+
+    def handle_internal_transfer(self, row: tuple) -> None:
+        """
+        Handles 'Intern överföring' (internal transfer between accounts).
+
+        In global mode: ignored (capital is pooled, transfers are no-ops).
+        In per-account mode: moves capital between accounts.
+          - Positive total (receiving account): adds capital without incrementing deposit stats.
+          - Negative total (sending account): removes capital from the oldest available month
+            in that account (FIFO), without affecting deposit stats.
+
+        Parameters:
+        row (tuple): A row from the transactions table in the database.
+        """
+        if not self.per_account:
+            self.handle_ignore(row)
+            return
+
+        account = row[1]
+        total = row[6]
+        month = self.allocate_to_month(row[0])
+
+        if total > 0:
+            # Receiving end: add capital to this account (not a deposit, so deposit stays unchanged)
+            self.data_cur.execute(
+                "INSERT OR IGNORE INTO month_account_data(month, account) VALUES(?,?)",
+                (month, account)
+            )
+            self.data_cur.execute(
+                "UPDATE month_account_data SET capital = capital + ? WHERE month = ? AND account = ?",
+                (total, month, account)
+            )
+            logging.debug(f"Internal transfer IN: +{total} to account {account} in month {month}")
+            # Reset transaction cursor so newly available capital can be used immediately
+            self.transaction_cur.execute("UPDATE transactions SET processed = 1 WHERE rowid = ?", (row[-1],))
+            self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, CASE WHEN transaction_type IN ('Insättning', 'Intern överföring') THEN 0 ELSE 1 END ASC, rowid ASC")
+        else:
+            # Sending end: remove capital from this account's oldest available months (FIFO)
+            amount = -total  # Make positive
+            month_capital = self.available_capital_for_account(account)
+            remaining = amount
+            for oldest_available, available in month_capital:
+                if remaining <= 0:
+                    break
+                month_amount = min(remaining, available)
+                self.data_cur.execute(
+                    "UPDATE month_account_data SET capital = capital - ? WHERE month = ? AND account = ?",
+                    (month_amount, oldest_available, account)
+                )
+                remaining -= month_amount
+            if remaining > 1e-3:
+                logging.warning(
+                    f"Internal transfer OUT: account {account} had insufficient capital "
+                    f"(needed {amount}, short by {remaining:.2f})"
+                )
+            logging.debug(f"Internal transfer OUT: -{amount} from account {account}")
+            self.transaction_cur.execute("UPDATE transactions SET processed = 1 WHERE rowid = ?", (row[-1],))
+            self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, CASE WHEN transaction_type IN ('Insättning', 'Intern överföring') THEN 0 ELSE 1 END ASC, rowid ASC")
 
     def handle_remove_shares(self, row: tuple) -> None:
         """
@@ -578,7 +688,7 @@ class DataParser:
                 i += 1
             # Reset transaction_cur
             self.transaction_cur.execute("UPDATE transactions SET processed = 1 WHERE rowid = ?", (row[-1],))
-            self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, rowid ASC")
+            self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, CASE WHEN transaction_type IN ('Insättning', 'Intern överföring') THEN 0 ELSE 1 END ASC, rowid ASC")
         else:
             # Not enough shares - this shouldn't happen for valid Byte transactions
             logging.warning(f"Not enough shares to remove for {asset}: have {total_asset_amount}, need {asset_amount}")
@@ -590,7 +700,7 @@ class DataParser:
         After attempting to processing all transactions, the function checks if there are any unprocessed transactions left.
         If there are, an AssetDeficit exception is raised and the database is rolled back. Otherwise, the changes are committed.
         """
-        unprocessed_lines = self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, rowid ASC")
+        unprocessed_lines = self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, CASE WHEN transaction_type IN ('Insättning', 'Intern överföring') THEN 0 ELSE 1 END ASC, rowid ASC")
         row = unprocessed_lines.fetchone()
         #Consider upgrading to python3.8 to make this more elegant with := statment
         while row is not None:
@@ -622,7 +732,7 @@ class DataParser:
             elif row[2] == "Tillgångsinsättning":
                 self.handle_asset_deposit(row)
             elif row[2] == "Intern överföring":
-                self.handle_ignore(row)
+                self.handle_internal_transfer(row)
             elif row[2] == "Värdepappersinsättning":
                 # Check if this is part of a "Byte" (change) transaction
                 # If amount is positive, it's adding shares (already handled by special cases converting to Tillgångsinsättning)


### PR DESCRIPTION
## Summary

Three bugs fixed that caused 18 processing failures and incorrect statistics in per-account mode.

## Changes

### 1. Handle `Intern överföring` in per-account mode
Added `handle_internal_transfer()` method. Previously all internal transfers were ignored (`handle_ignore`), which meant account 7485272 never received capital transferred from account 7485280, causing all subsequent purchases to fail.

- Positive total (receiving account): adds capital without incrementing deposit stats
- Negative total (sending account): drains capital via FIFO
- Global mode: falls back to `handle_ignore` (no behaviour change)

### 2. Fix transaction ordering bug
Within the same date, deposits and internal transfers are now processed before purchases. Previously, if a purchase had a lower rowid than a same-day deposit (common in Avanza CSV exports), the purchase would fail with insufficient capital.

Added `CASE WHEN transaction_type IN ('Insättning', 'Intern överföring') THEN 0 ELSE 1 END` to all 15 ORDER BY clauses.

### 3. Fix complex number crash in `calculate_stats`
When a month's loss exceeds 100% of its deposit, `total_gainloss_per/100 + 1` goes negative. Raising a negative number to a fractional power (for annualised yield) produces a complex number in Python, crashing the SQLite insert. Fixed by setting `annual_per_yield = None` when the base is ≤ 0.

## Testing

- All 27 tests pass (`python3 -m pytest test/ -v`)
- Real data: all 806 transactions process cleanly in per-account mode (previously 18 failures)
- Jan/Feb 2026 stats now show correct realized gains (~11 SEK interest, not 68/18 SEK)