### PR TITLE
Remove legacy CLI commands and streamline interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,26 +72,6 @@ python cli.py status
 python cli.py reset
 ```
 
-#### Legacy Commands (Backward Compatible)
-
-```bash
-# Parse a CSV file (automatically detects old/new Avanza format)
-python cli.py parse data/newdata.csv
-
-# Process transactions already in the database
-python cli.py process
-
-# Fetch latest prices from Avanza API
-python cli.py update-prices
-
-# Calculate monthly and yearly statistics
-python cli.py calculate-stats
-
-# Show statistics (default: month, current deposits)
-python cli.py show-stats
-python cli.py show-stats --period year --deposits all --accumulated
-```
-
 All commands accept optional `--database` and `--special-cases` arguments to override default paths:
 
 ```bash
@@ -114,7 +94,7 @@ The statistics output has two modes that serve different purposes:
 
 #### 1. Regular Statistics (Default)
 ```bash
-python cli.py show-stats --period month
+python cli.py stats --period month
 ```
 - **Shows**: Activity for each specific month/year
 - **"Value" column**: Current value of deposits made **during that specific period**
@@ -124,7 +104,7 @@ python cli.py show-stats --period month
 
 #### 2. Accumulated Statistics
 ```bash
-python cli.py show-stats --period month --accumulated
+python cli.py stats --period month --accumulated
 ```
 - **Shows**: Cumulative portfolio value over time
 - **"Value" column**: Total portfolio value at period end (all assets held)
@@ -165,18 +145,17 @@ The parser automatically detects whether your CSV file uses Avanza's old or new 
 
 Empty numeric fields (like `Antal`, `Kurs`) are treated as zero.
 
-**Price fetching note:** The `update-prices` command (and the original `calculate_stats.py`) fetches current asset prices from Avanza's public search API (`www.avanza.se/_api/search/filtered-search`). This API is intended for web frontend use and may have rate limits or terms of service restrictions. Use at your own risk and consider using official APIs if available. Always review the website's terms of service before using their data.
+**Price fetching note:** The `stats` command (with `--update-prices auto` or `--update-prices always`) fetches current asset prices from Avanza's public search API (`www.avanza.se/_api/search/filtered-search`). This API is intended for web frontend use and may have rate limits or terms of service restrictions. Use at your own risk and consider using official APIs if available. Always review the website's terms of service before using their data.
 
-### Original Scripts (Alternative)
+### Using the CLI (Recommended)
 
-You can still use the original scripts directly, though the CLI is recommended:
+The unified CLI provides all functionality in a streamlined interface:
 
-1. Add data in the `data` folder.
+1. Add transaction data in CSV format to the `data` folder.
     - You might need to create a "special_cases.json" file in order to match and replace certain values in the data. See file specification in the documentation for the SpecialCases class.
-    - You will probably need to update the process_transactions function in the DataParser class to match your data.
-2. Run the script "data_parser.py" with `python data_parser.py`.
-3. Run the script calculate_stats.py with `python calculate_stats.py`.
-    - Note: This script fetches current asset prices from Avanza's public search API (`www.avanza.se/_api/search/filtered-search`). This API is intended for web frontend use and may have rate limits or terms of service restrictions. Use at your own risk and consider using official APIs if available. Always review the website's terms of service before using their data.
+2. Import and process transactions: `python cli.py import data/your_transactions.csv`
+3. View statistics with automatic price updates: `python cli.py stats --update-prices auto`
+4. Check system status: `python cli.py status`
 
 ## Contributing
 

--- a/cli.py
+++ b/cli.py
@@ -114,66 +114,80 @@ def import_data(args):
         return 1
 
 
-def update_prices(args, force=False):
-    """Update prices for all assets."""
+
+
+
+
+
+
+
+
+
+def stats(args):
+    """Smart statistics command with automatic updates."""
     db = get_db(args)
     
-    if not force:
+    # Update prices if needed
+    if args.update_prices == 'always':
+        # Force price update
         fresh, oldest_date = prices_are_fresh(db)
         if fresh:
-            logging.info(f"Prices are already fresh (oldest: {oldest_date})")
-            return 0
+            logging.info(f"Prices are already fresh (oldest: {oldest_date}), updating anyway...")
+        try:
+            stat_calc = StatCalculator(db)
+            stat_calc.update_prices()
+            
+            # Update metadata
+            now = datetime.now().isoformat()
+            db.set_metadata('last_price_update', now)
+            
+            # Clear stats timestamp since prices changed
+            db.set_metadata('last_stats_calculation', '')
+            
+            logging.info("Prices updated successfully")
+        except Exception as e:
+            logging.error(f"Failed to update prices: {e}")
+            return 1
+            
+    elif args.update_prices == 'auto':
+        fresh, oldest_date = prices_are_fresh(db)
+        if not fresh:
+            logging.info(f"Prices are stale (oldest: {oldest_date}), updating...")
+            try:
+                stat_calc = StatCalculator(db)
+                stat_calc.update_prices()
+                
+                # Update metadata
+                now = datetime.now().isoformat()
+                db.set_metadata('last_price_update', now)
+                
+                # Clear stats timestamp since prices changed
+                db.set_metadata('last_stats_calculation', '')
+                
+                logging.info("Prices updated successfully")
+            except Exception as e:
+                logging.error(f"Failed to update prices: {e}")
+                return 1
     
+    # Calculate stats if needed
+    if args.force or stats_need_recalculation(db):
+        try:
+            stat_calc = StatCalculator(db)
+            stat_calc.calculate_month_stats()
+            stat_calc.calculate_year_stats()
+            
+            # Update metadata
+            now = datetime.now().isoformat()
+            db.set_metadata('last_stats_calculation', now)
+            
+            logging.info("Statistics calculated")
+        except Exception as e:
+            logging.error(f"Failed to calculate statistics: {e}")
+            return 1
+    
+    # Display statistics
     try:
         stat_calc = StatCalculator(db)
-        stat_calc.update_prices()
-        
-        # Update metadata
-        now = datetime.now().isoformat()
-        db.set_metadata('last_price_update', now)
-        
-        # Clear stats timestamp since prices changed
-        db.set_metadata('last_stats_calculation', '')
-        
-        logging.info("Prices updated successfully")
-        return 0
-        
-    except Exception as e:
-        logging.error(f"Failed to update prices: {e}")
-        return 1
-
-
-def calculate_stats(args, force=False):
-    """Calculate statistics if needed."""
-    db = get_db(args)
-    
-    if not force and not stats_need_recalculation(db):
-        logging.info("Statistics are up to date")
-        return 0
-    
-    try:
-        stat_calc = StatCalculator(db)
-        stat_calc.calculate_month_stats()
-        stat_calc.calculate_year_stats()
-        
-        # Update metadata
-        now = datetime.now().isoformat()
-        db.set_metadata('last_stats_calculation', now)
-        
-        logging.info("Statistics calculated")
-        return 0
-        
-    except Exception as e:
-        logging.error(f"Failed to calculate statistics: {e}")
-        return 1
-
-
-def show_stats(args):
-    """Display statistics."""
-    db = get_db(args)
-    stat_calc = StatCalculator(db)
-    
-    try:
         kwargs = {'period': args.period, 'deposits': args.deposits}
         
         if args.accumulated:
@@ -185,27 +199,6 @@ def show_stats(args):
     except Exception as e:
         logging.error(f"Failed to show statistics: {e}")
         return 1
-
-
-def stats(args):
-    """Smart statistics command with automatic updates."""
-    db = get_db(args)
-    
-    # Update prices if needed
-    if args.update_prices == 'always':
-        update_prices(args, force=True)
-    elif args.update_prices == 'auto':
-        fresh, oldest_date = prices_are_fresh(db)
-        if not fresh:
-            logging.info(f"Prices are stale (oldest: {oldest_date}), updating...")
-            update_prices(args, force=True)
-    
-    # Calculate stats if needed
-    if args.force or stats_need_recalculation(db):
-        calculate_stats(args, force=True)
-    
-    # Show stats
-    return show_stats(args)
 
 
 def status(args):
@@ -339,12 +332,7 @@ Examples:
     reset_parser = subparsers.add_parser('reset', help='Reset database state')
     reset_parser.set_defaults(func=reset)
     
-    # Legacy commands (for compatibility)
-    legacy_parser = subparsers.add_parser('update-prices', help='[Legacy] Update prices')
-    legacy_parser.set_defaults(func=lambda args: update_prices(args, force=True))
-    
-    legacy_parser = subparsers.add_parser('calculate-stats', help='[Legacy] Calculate statistics')
-    legacy_parser.set_defaults(func=lambda args: calculate_stats(args, force=True))
+
     
     args = parser.parse_args()
     


### PR DESCRIPTION
## Summary

This PR removes legacy CLI commands and streamlines the interface for better user experience.

## Changes

### 1. **Removed Legacy Commands:**
- `update-prices` - Price updates are now handled automatically by the `stats` command
- `calculate-stats` - Statistics calculation is now handled automatically by the `stats` command  
- `show-stats` - Replaced by the unified `stats` command

### 2. **Updated CLI Interface:**
- Only 4 commands remain: `import`, `stats`, `status`, `reset`
- The `stats` command now directly implements all logic (price updates, statistics calculation, display)
- Smart update features preserved: `--update-prices auto` only updates when prices are stale

### 3. **Updated README:**
- Removed 'Legacy Commands' section
- Updated all examples to use modern commands
- Replaced 'Original Scripts' section with 'Using the CLI (Recommended)'
- Updated price fetching note to reference `stats` command

### 4. **Benefits:**
- **Simpler interface**: Users don't need to remember multiple commands
- **Automatic updates**: `stats` command handles everything automatically
- **Better UX**: Less cognitive load, fewer steps needed
- **Cleaner code**: Removed redundant functions and logic

## Testing
- All modern commands work correctly: `import`, `stats`, `status`, `reset`
- `stats --update-prices auto` properly updates prices only when stale
- `stats --update-prices never` skips price updates
- `stats --update-prices always` forces price updates
- Statistics display correctly in both regular and accumulated modes

## Migration
Users should update their workflows:
- Replace `python cli.py update-prices` with `python cli.py stats --update-prices always`
- Replace `python cli.py calculate-stats` with `python cli.py stats --force`
- Replace `python cli.py show-stats` with `python cli.py stats`

The `stats` command with `--update-prices auto` (default) provides the same functionality as the old three-command workflow but automatically.