### PR TITLE
Add account summary functionality

### DIFF
--- a/calculate_stats.py
+++ b/calculate_stats.py
@@ -418,6 +418,94 @@ class StatCalculator:
 
         self.db.commit()
 
+    def summarize_accounts(self) -> list:
+        """
+        Summarize current value and cash amount for each account.
+        
+        Returns:
+        list: List of tuples (account, asset_value, cash, total_value)
+        """
+        self.db.connect()
+        cur = self.db.get_cursor()
+        
+        # Get cash per account
+        account_cash = cur.execute(
+            "SELECT account, SUM(capital) FROM month_data GROUP BY account"
+        ).fetchall()
+        
+        # Get asset value per month
+        month_asset_values = cur.execute("""
+            SELECT ma.month, SUM(ma.amount * a.latest_price) as month_value
+            FROM month_assets ma
+            JOIN assets a ON ma.asset_id = a.asset_id
+            WHERE ma.amount > 0 AND a.latest_price IS NOT NULL
+            GROUP BY ma.month
+        """).fetchall()
+        
+        # Convert to dict for easy lookup
+        month_values = {month: value for month, value in month_asset_values}
+        
+        # Get deposits per account per month
+        account_month_deposits = cur.execute("""
+            SELECT month, account, deposit
+            FROM month_data 
+            WHERE deposit > 0
+        """).fetchall()
+        
+        # Calculate total deposits per month
+        month_total_deposits = {}
+        for month, account, deposit in account_month_deposits:
+            month_total_deposits[month] = month_total_deposits.get(month, 0) + deposit
+        
+        # Distribute month asset values to accounts based on deposit proportions
+        account_assets = {}
+        for month, account, deposit in account_month_deposits:
+            if month in month_values and month in month_total_deposits:
+                month_value = month_values[month]
+                total_deposit = month_total_deposits[month]
+                if total_deposit > 0:
+                    account_share = month_value * (deposit / total_deposit)
+                    account_assets[account] = account_assets.get(account, 0) + account_share
+        
+        # Combine cash and assets
+        result = []
+        for account, cash in account_cash:
+            asset_value = account_assets.get(account, 0)
+            total_value = asset_value + cash
+            result.append((account, asset_value, cash, total_value))
+        
+        # Sort by account name
+        result.sort(key=lambda x: x[0])
+        return result
+
+    def print_account_summary(self) -> None:
+        """
+        Print a summary of current value and cash for each account.
+        """
+        accounts = self.summarize_accounts()
+        
+        if not accounts:
+            print("No account data available.")
+            return
+        
+        print("\n=== Account Summary ===")
+        print(f"{'Account':<12} {'Assets':>12} {'Cash':>12} {'Total':>12}")
+        print("-" * 48)
+        
+        total_assets = 0
+        total_cash = 0
+        total_all = 0
+        
+        for account, asset_value, cash, total_value in accounts:
+            print(f"{account:<12} {asset_value:>12.0f} {cash:>12.0f} {total_value:>12.0f}")
+            total_assets += asset_value
+            total_cash += cash
+            total_all += total_value
+        
+        print("-" * 48)
+        print(f"{'TOTAL':<12} {total_assets:>12.0f} {total_cash:>12.0f} {total_all:>12.0f}")
+        print()
+
 if __name__ == "__main__":
     db = DatabaseHandler("data/asset_data.db")
     stat_calculator = StatCalculator(db)
@@ -429,3 +517,5 @@ if __name__ == "__main__":
     print("Year stats:")
     stat_calculator.print_stats(period="year",deposits="current")
     stat_calculator.print_accumulated(period="year",deposits="current")
+    print("Account summary:")
+    stat_calculator.print_account_summary()

--- a/cli.py
+++ b/cli.py
@@ -208,6 +208,13 @@ def stats(args):
     # Display statistics
     try:
         stat_calc = StatCalculator(db)
+        
+        # Show account summary if requested
+        if args.accounts:
+            stat_calc.print_account_summary()
+            return 0
+        
+        # Otherwise show regular statistics
         kwargs = {'period': args.period, 'deposits': args.deposits}
         
         if args.accumulated:
@@ -341,6 +348,11 @@ Examples:
         '--force',
         action='store_true',
         help='Force statistics recalculation'
+    )
+    stats_parser.add_argument(
+        '--accounts',
+        action='store_true',
+        help='Show account summary (assets and cash per account)'
     )
     stats_parser.set_defaults(func=stats)
     


### PR DESCRIPTION
## Summary

Adds account summary functionality to show current value and cash for each account.

## Changes

1. **New summarize_accounts() method in StatCalculator class**
   - Calculates cash per account from month_data table
   - Calculates asset value per month from month_assets and assets tables
   - Attributes asset values to accounts based on FIFO logic:
     - Assets are attributed to the month they were purchased
     - Month asset values are distributed to accounts based on deposit proportions
     - If multiple accounts deposited in the same month, assets are split proportionally

2. **New print_account_summary() method**
   - Formats and prints a clean table with account summary
   - Shows assets, cash, and total value for each account
   - Includes totals at the bottom

3. **New --accounts flag for stats command**
   - Shows account summary instead of regular statistics
   - Takes precedence over other stats flags
   - Clean integration with existing CLI interface

## Example Output (with placeholder values)


## Known Issues

1. **Savings account asset attribution bug**
   Savings accounts incorrectly show assets when they should only have cash.

   **Root cause**: The attribution logic assumes that assets purchased in a month are purchased with money deposited in that same account/month. However, money may be transferred between accounts (e.g., from savings to investment accounts) before being used to purchase assets.

   **Impact**: Savings account asset values are overstated, and investment accounts' asset values are understated by the same amount.

2. **Internal transfer handling**
   The system doesn't account for internal transfer transactions when attributing assets. Money transferred between accounts should affect which account gets credit for asset purchases.

## Testing
- Tested with real transaction data
- Account summary displays correctly formatted table
- Regular statistics still work when --accounts flag is not used
- CLI help updated to show new --accounts flag

## Future Improvements
1. Fix savings account attribution bug by tracking internal transfers
2. Consider adding separate command for account summary (not just a flag)
3. Add percentage breakdowns for each account
4. Support filtering by specific accounts