### PR TITLE
Refactor ambiguous 'month' naming to 'cohort' terminology

### DIFF
--- a/calculate_stats.py
+++ b/calculate_stats.py
@@ -80,14 +80,14 @@ class StatCalculator:
             cur.execute(f"DROP TABLE IF EXISTS {table}")
         
         # Check if per-account tables exist
-        cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='account_month_stats'")
+        cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='account_cohort_stats'")
         if cur.fetchone():
             # Tables exist
             return
         
-        # Create account_month_stats
+        # Create account_cohort_stats
         cur.execute("""
-            CREATE TABLE account_month_stats (
+            CREATE TABLE account_cohort_stats (
                 account TEXT NOT NULL,
                 month DATE NOT NULL,
                 deposit REAL,
@@ -135,8 +135,8 @@ class StatCalculator:
         
         self.db.commit()
         # Ensure updated table state exists locally to prevent KeyError exceptions
-        if 'account_month_stats' not in self.db.tables:
-            self.db.tables.extend(['account_month_stats', 'account_year_stats'])
+        if 'account_cohort_stats' not in self.db.tables:
+            self.db.tables.extend(['account_cohort_stats', 'account_year_stats'])
         logging.info("Created per-account statistics tables (dropped old global tables)")
     
     def _drop_old_tables(self):
@@ -227,7 +227,7 @@ class StatCalculator:
         if apy_mode == 'twrr':
             cur.execute(f"""
                 SELECT SUM(active_base)
-                FROM month_data
+                FROM cohort_data
                 WHERE month = ? AND account IN ({placeholders})
             """, (month_str,) + tuple(accounts))
             ab_row = cur.fetchone()
@@ -242,7 +242,7 @@ class StatCalculator:
             # Check for closed positions with snapshot
             cur.execute(f"""
                 SELECT SUM(deposit * closed_return), SUM(deposit)
-                FROM month_data
+                FROM cohort_data
                 WHERE month = ? AND account IN ({placeholders}) AND closed_return IS NOT NULL
             """, (month_str,) + tuple(accounts))
             cr_row = cur.fetchone()
@@ -281,7 +281,7 @@ class StatCalculator:
         if apy_mode == 'twrr':
             cur.execute(f"""
                 SELECT SUM(active_base)
-                FROM month_data
+                FROM cohort_data
                 WHERE strftime('%Y', month) = ? AND account IN ({placeholders})
             """, (year_str,) + tuple(accounts))
             ab_row = cur.fetchone()
@@ -296,7 +296,7 @@ class StatCalculator:
             # Check for closed positions with snapshot
             cur.execute(f"""
                 SELECT SUM(deposit * closed_return), SUM(deposit)
-                FROM month_data
+                FROM cohort_data
                 WHERE strftime('%Y', month) = ? AND account IN ({placeholders}) AND closed_return IS NOT NULL
             """, (year_str,) + tuple(accounts))
             cr_row = cur.fetchone()
@@ -328,7 +328,7 @@ class StatCalculator:
     def calculate_month_stats(self, apy_mode='modified-dietz'):
         """
         Calculate monthly stats such as capital transfers and gain/loss.
-        Stores results in account_month_stats table (per account).
+        Stores results in account_cohort_stats table (per account).
         
         Parameters:
         apy_mode (str): 'modified-dietz' or 'twrr'
@@ -336,15 +336,15 @@ class StatCalculator:
         self._ensure_per_account_tables()
         self.db.connect()
         
-        # Reset account_month_stats table
-        self.db.reset_table("account_month_stats")
+        # Reset account_cohort_stats table
+        self.db.reset_table("account_cohort_stats")
         
         cur = self.db.get_cursor()
         today = datetime.today().date()
         
         # Get all accounts
         accounts = [row[0] for row in cur.execute(
-            "SELECT DISTINCT account FROM month_data ORDER BY account"
+            "SELECT DISTINCT account FROM cohort_data ORDER BY account"
         ).fetchall()]
         
         logging.info(f"Calculating monthly stats for {len(accounts)} accounts")
@@ -353,7 +353,7 @@ class StatCalculator:
             # Get all months for this account in chronological order
             cur.execute("""
                 SELECT month, deposit, withdrawal, capital, active_base, closed_return
-                FROM month_data
+                FROM cohort_data
                 WHERE account = ?
                 ORDER BY month ASC
             """, (account,))
@@ -380,7 +380,7 @@ class StatCalculator:
                 # Get asset holdings for this account in this month
                 cur.execute("""
                     SELECT ma.asset_id, ma.amount, a.latest_price
-                    FROM month_assets ma
+                    FROM cohort_assets ma
                     JOIN assets a ON ma.asset_id = a.asset_id
                     WHERE ma.account = ? AND ma.month = ? AND ma.amount > 0.001
                     AND a.latest_price IS NOT NULL
@@ -446,7 +446,7 @@ class StatCalculator:
                 
                 # Insert into per-account table
                 cur.execute("""
-                    INSERT INTO account_month_stats (
+                    INSERT INTO account_cohort_stats (
                         account, month, deposit, withdrawal, value,
                         total_gainloss, realized_gainloss, unrealized_gainloss,
                         total_gainloss_per, realized_gainloss_per, unrealized_gainloss_per,
@@ -483,7 +483,7 @@ class StatCalculator:
         
         # Get all accounts
         accounts = [row[0] for row in cur.execute(
-            "SELECT DISTINCT account FROM account_month_stats ORDER BY account"
+            "SELECT DISTINCT account FROM account_cohort_stats ORDER BY account"
         ).fetchall()]
         
         logging.info(f"Calculating yearly stats for {len(accounts)} accounts")
@@ -492,7 +492,7 @@ class StatCalculator:
             # Get all years for this account
             cur.execute("""
                 SELECT DISTINCT strftime('%Y', month) as year
-                FROM account_month_stats
+                FROM account_cohort_stats
                 WHERE account = ?
                 ORDER BY year
             """, (account,))
@@ -502,7 +502,7 @@ class StatCalculator:
                 # Sum cohort deposits, withdrawals, and cash capital for the entire year
                 cur.execute("""
                     SELECT SUM(deposit), SUM(withdrawal), SUM(capital), SUM(active_base)
-                    FROM month_data
+                    FROM cohort_data
                     WHERE account = ? AND strftime('%Y', month) = ?
                 """, (account, year_str))
                 dep_row = cur.fetchone()
@@ -514,7 +514,7 @@ class StatCalculator:
                 # Get deposit-weighted closed_return for closed cohorts in this year
                 cur.execute("""
                     SELECT SUM(deposit * closed_return), SUM(deposit)
-                    FROM month_data
+                    FROM cohort_data
                     WHERE account = ? AND strftime('%Y', month) = ? AND closed_return IS NOT NULL
                 """, (account, year_str))
                 cr_row = cur.fetchone()
@@ -526,7 +526,7 @@ class StatCalculator:
                 # Sum cohort asset holdings for the entire year
                 cur.execute("""
                     SELECT ma.asset_id, SUM(ma.amount), a.latest_price
-                    FROM month_assets ma
+                    FROM cohort_assets ma
                     JOIN assets a ON ma.asset_id = a.asset_id
                     WHERE ma.account = ? AND strftime('%Y', ma.month) = ? AND ma.amount > 0.001
                     AND a.latest_price IS NOT NULL
@@ -562,7 +562,7 @@ class StatCalculator:
                 # Get last month of the year for accumulated values
                 cur.execute("""
                     SELECT acc_net_deposit, acc_deposit, acc_value, acc_unrealized_gainloss, acc_total_gainloss
-                    FROM account_month_stats
+                    FROM account_cohort_stats
                     WHERE account = ? AND strftime('%Y', month) = ?
                     ORDER BY month DESC
                     LIMIT 1
@@ -663,7 +663,7 @@ class StatCalculator:
         # If no accounts specified, use all accounts (global view)
         if accounts is None:
             accounts = [row[0] for row in cur.execute(
-                "SELECT DISTINCT account FROM account_month_stats ORDER BY account"
+                "SELECT DISTINCT account FROM account_cohort_stats ORDER BY account"
             ).fetchall()]
         
         # Single account - direct query from cached tables
@@ -675,7 +675,7 @@ class StatCalculator:
                            total_gainloss, realized_gainloss, unrealized_gainloss,
                            total_gainloss_per, realized_gainloss_per, unrealized_gainloss_per,
                            annual_per_yield
-                    FROM account_month_stats
+                    FROM account_cohort_stats
                     WHERE account = ?
                     ORDER BY month
                 """
@@ -717,7 +717,7 @@ class StatCalculator:
                        SUM(total_gainloss) as total_gainloss,
                        SUM(realized_gainloss) as realized_gainloss,
                        SUM(unrealized_gainloss) as unrealized_gainloss
-                FROM account_month_stats
+                FROM account_cohort_stats
                 WHERE account IN ({placeholders})
                 GROUP BY month
                 ORDER BY month
@@ -846,7 +846,7 @@ class StatCalculator:
         # If no accounts specified, use all accounts
         if accounts is None:
             accounts = [row[0] for row in cur.execute(
-                "SELECT DISTINCT account FROM account_month_stats ORDER BY account"
+                "SELECT DISTINCT account FROM account_cohort_stats ORDER BY account"
             ).fetchall()]
         
         deposit_col = "acc_deposit" if deposits == "all" else "acc_net_deposit"
@@ -858,7 +858,7 @@ class StatCalculator:
             if period == "month":
                 query = f"""
                     SELECT month, {deposit_col}, acc_value, {gainloss_col}
-                    FROM account_month_stats
+                    FROM account_cohort_stats
                     WHERE account = ?
                     ORDER BY month
                 """
@@ -888,7 +888,7 @@ class StatCalculator:
         if period == "month":
             query = f"""
                 SELECT month, account, {deposit_col}, acc_value, {gainloss_col}
-                FROM account_month_stats
+                FROM account_cohort_stats
                 WHERE account IN ({placeholders})
                 ORDER BY month
             """
@@ -1082,20 +1082,20 @@ class StatCalculator:
         # If no accounts specified, use all accounts
         if accounts is None:
             accounts = [row[0] for row in cur.execute(
-                "SELECT DISTINCT account FROM month_data ORDER BY account"
+                "SELECT DISTINCT account FROM cohort_data ORDER BY account"
             ).fetchall()]
         
         summaries = []
         for account in accounts:
             # Get TOTAL cash balance for this account across ALL months (cohorts)
-            cur.execute("SELECT SUM(capital) FROM month_data WHERE account = ?", (account,))
+            cur.execute("SELECT SUM(capital) FROM cohort_data WHERE account = ?", (account,))
             cash_row = cur.fetchone()
             cash = cash_row[0] if cash_row and cash_row[0] else 0.0
             
             # Get TOTAL asset holdings for this account across ALL months (cohorts)
             cur.execute("""
                 SELECT SUM(ma.amount * a.latest_price)
-                FROM month_assets ma
+                FROM cohort_assets ma
                 JOIN assets a ON ma.asset_id = a.asset_id
                 WHERE ma.account = ? AND ma.amount > 0.001
                 AND a.latest_price IS NOT NULL

--- a/data_parser.py
+++ b/data_parser.py
@@ -250,11 +250,11 @@ class DataParser:
     
     def reset_processed_transactions(self) -> None:
         """
-        Resets the processed flag for all transactions in the database. Also resets month_data, month_assets, assets and cohort_cash_flows tables.
+        Resets the processed flag for all transactions in the database. Also resets cohort_data, cohort_assets, assets and cohort_cash_flows tables.
         """
         self.data_cur.execute("UPDATE transactions SET processed = 0")
-        self.db.reset_table("month_data")
-        self.db.reset_table("month_assets")
+        self.db.reset_table("cohort_data")
+        self.db.reset_table("cohort_assets")
         self.db.reset_table("assets")
         self.db.reset_table("cohort_cash_flows")
         self.db.commit()
@@ -300,7 +300,7 @@ class DataParser:
         """
         # Get cash for this cohort
         row = self.data_cur.execute(
-            "SELECT capital FROM month_data WHERE month = ? AND account = ?",
+            "SELECT capital FROM cohort_data WHERE month = ? AND account = ?",
             (cohort_month, account)
         ).fetchone()
         cash = row[0] if row else 0.0
@@ -308,7 +308,7 @@ class DataParser:
         # Get asset values for this cohort using latest_price from assets table
         asset_value = self.data_cur.execute("""
             SELECT COALESCE(SUM(ma.amount * COALESCE(a.latest_price, ma.average_price)), 0)
-            FROM month_assets ma
+            FROM cohort_assets ma
             JOIN assets a ON ma.asset_id = a.asset_id
             WHERE ma.month = ? AND ma.account = ? AND ma.amount > 0
         """, (cohort_month, account)).fetchone()[0]
@@ -327,7 +327,7 @@ class DataParser:
         list: List of (month, capital) tuples with capital > 0 for that account.
         """
         res = self.data_cur.execute(
-            "SELECT month, capital FROM month_data WHERE account = ? AND capital > 0 ORDER BY month ASC",
+            "SELECT month, capital FROM cohort_data WHERE account = ? AND capital > 0 ORDER BY month ASC",
             (account,)
         ).fetchall()
         return res if res else [(None, 0)]
@@ -344,9 +344,9 @@ class DataParser:
         list: List of tuples with the first element being the month and the second element being the amount of available assets for that month.
         """
         if account:
-            res = self.data_cur.execute("SELECT month, amount FROM month_assets WHERE amount > 0 AND asset_id = ? AND account = ? ORDER BY month ASC",(asset_id, account)).fetchall()
+            res = self.data_cur.execute("SELECT month, amount FROM cohort_assets WHERE amount > 0 AND asset_id = ? AND account = ? ORDER BY month ASC",(asset_id, account)).fetchall()
         else:
-            res = self.data_cur.execute("SELECT month, amount FROM month_assets WHERE amount > 0 AND asset_id = ? ORDER BY month ASC",(asset_id,)).fetchall()
+            res = self.data_cur.execute("SELECT month, amount FROM cohort_assets WHERE amount > 0 AND asset_id = ? ORDER BY month ASC",(asset_id,)).fetchall()
         
         if len(res) > 0:
             return res
@@ -363,8 +363,8 @@ class DataParser:
         month = self.allocate_to_month(row[0])
         amount = row[6]
         account = row[1]
-        self.data_cur.execute("INSERT OR IGNORE INTO month_data(month, account) VALUES(?,?)", (month, account))
-        self.data_cur.execute("UPDATE month_data SET capital = capital + ?, deposit = deposit + ?, active_base = active_base + ? WHERE month = ? AND account = ?", (amount, amount, amount, month, account))
+        self.data_cur.execute("INSERT OR IGNORE INTO cohort_data(month, account) VALUES(?,?)", (month, account))
+        self.data_cur.execute("UPDATE cohort_data SET capital = capital + ?, deposit = deposit + ?, active_base = active_base + ? WHERE month = ? AND account = ?", (amount, amount, amount, month, account))
         # Reset transaction_cur since new funds are available
         self.transaction_cur.execute("UPDATE transactions SET processed = 1 WHERE rowid = ?",(row[-1],))
         self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, rowid ASC")
@@ -401,18 +401,18 @@ class DataParser:
                     # Snapshot TWRR before zeroing active_base on full withdrawal
                     if r >= 1.0 - 1e-6:
                         ab_row = self.data_cur.execute(
-                            "SELECT active_base FROM month_data WHERE month = ? AND account = ?",
+                            "SELECT active_base FROM cohort_data WHERE month = ? AND account = ?",
                             (oldest_available, account)).fetchone()
                         ab = ab_row[0] if ab_row and ab_row[0] else 0.0
                         if ab > 1e-4:
                             self.data_cur.execute(
-                                "UPDATE month_data SET closed_return = ? WHERE month = ? AND account = ?",
+                                "UPDATE cohort_data SET closed_return = ? WHERE month = ? AND account = ?",
                                 (cv / ab, oldest_available, account))
                     self.data_cur.execute(
-                        "UPDATE month_data SET active_base = active_base * (1 - ?) WHERE month = ? AND account = ?",
+                        "UPDATE cohort_data SET active_base = active_base * (1 - ?) WHERE month = ? AND account = ?",
                         (r, oldest_available, account))
 
-                self.data_cur.execute("UPDATE month_data SET capital = capital - ?, withdrawal = withdrawal + ? WHERE month = ? AND account = ?", (month_amount, month_amount, oldest_available, account))
+                self.data_cur.execute("UPDATE cohort_data SET capital = capital - ?, withdrawal = withdrawal + ? WHERE month = ? AND account = ?", (month_amount, month_amount, oldest_available, account))
                 
                 # Aggregate cash flow for the cohort in the transaction month
                 self.data_cur.execute("""
@@ -455,11 +455,11 @@ class DataParser:
                 (oldest_available,capital) = month_capital[i]
                 month_amount = min(remaining_amount,capital)
                 month_asset_amount = month_amount / total_amount * asset_amount
-                self.data_cur.execute("UPDATE month_data SET capital = capital - ? WHERE month = ? AND account = ?", (month_amount, oldest_available, account))
-                self.data_cur.execute("INSERT OR IGNORE INTO month_assets(month,asset_id,account) VALUES (?,?,?)",(oldest_available,asset_id,account))
-                self.data_cur.execute("UPDATE month_assets SET average_price = ?/(amount+?)*?+amount/(amount+?)*average_price WHERE month = ? AND asset_id = ? AND account = ?",(month_amount,month_amount,price,month_amount,oldest_available,asset_id,account))
-                self.data_cur.execute("UPDATE month_assets SET average_purchase_price = ?/(purchased_amount+?)*?+purchased_amount/(purchased_amount+?)*average_purchase_price WHERE month = ? AND asset_id = ? AND account = ?",(month_amount,month_amount,price,month_amount,oldest_available,asset_id,account))
-                self.data_cur.execute("UPDATE month_assets SET amount = amount + ?, purchased_amount = purchased_amount + ? WHERE month = ? AND asset_id = ? AND account = ?",(month_asset_amount, month_asset_amount, oldest_available,asset_id,account))
+                self.data_cur.execute("UPDATE cohort_data SET capital = capital - ? WHERE month = ? AND account = ?", (month_amount, oldest_available, account))
+                self.data_cur.execute("INSERT OR IGNORE INTO cohort_assets(month,asset_id,account) VALUES (?,?,?)",(oldest_available,asset_id,account))
+                self.data_cur.execute("UPDATE cohort_assets SET average_price = ?/(amount+?)*?+amount/(amount+?)*average_price WHERE month = ? AND asset_id = ? AND account = ?",(month_amount,month_amount,price,month_amount,oldest_available,asset_id,account))
+                self.data_cur.execute("UPDATE cohort_assets SET average_purchase_price = ?/(purchased_amount+?)*?+purchased_amount/(purchased_amount+?)*average_purchase_price WHERE month = ? AND asset_id = ? AND account = ?",(month_amount,month_amount,price,month_amount,oldest_available,asset_id,account))
+                self.data_cur.execute("UPDATE cohort_assets SET amount = amount + ?, purchased_amount = purchased_amount + ? WHERE month = ? AND asset_id = ? AND account = ?",(month_asset_amount, month_asset_amount, oldest_available,asset_id,account))
                 remaining_amount -= month_amount
                 i += 1
             # Reset transaction_cur since new assets are available
@@ -494,10 +494,10 @@ class DataParser:
                 (oldest_available,amount) = month_asset_amounts[i]
                 month_amount = min(remaining_amount,amount)
                 month_capital_amount = month_amount / asset_amount * total_amount
-                self.data_cur.execute("UPDATE month_assets SET average_sale_price = ?/(sold_amount+?)*?+sold_amount/(sold_amount+?)*average_sale_price WHERE month = ? AND asset_id = ? AND account = ?",(month_amount,month_amount,price,month_amount,oldest_available,asset_id,account))
-                self.data_cur.execute("UPDATE month_assets SET amount = amount - ?, sold_amount = sold_amount + ? WHERE month = ? AND asset_id = ? AND account = ?",(month_amount, month_amount, oldest_available,asset_id,account))
-                self.data_cur.execute("INSERT OR IGNORE INTO month_data(month, account) VALUES(?,?)", (oldest_available, account))
-                self.data_cur.execute("UPDATE month_data SET capital = capital + ? WHERE month = ? AND account = ?", (month_capital_amount, oldest_available, account))
+                self.data_cur.execute("UPDATE cohort_assets SET average_sale_price = ?/(sold_amount+?)*?+sold_amount/(sold_amount+?)*average_sale_price WHERE month = ? AND asset_id = ? AND account = ?",(month_amount,month_amount,price,month_amount,oldest_available,asset_id,account))
+                self.data_cur.execute("UPDATE cohort_assets SET amount = amount - ?, sold_amount = sold_amount + ? WHERE month = ? AND asset_id = ? AND account = ?",(month_amount, month_amount, oldest_available,asset_id,account))
+                self.data_cur.execute("INSERT OR IGNORE INTO cohort_data(month, account) VALUES(?,?)", (oldest_available, account))
+                self.data_cur.execute("UPDATE cohort_data SET capital = capital + ? WHERE month = ? AND account = ?", (month_capital_amount, oldest_available, account))
                 remaining_amount -= month_amount
                 i += 1
             # Reset transaction_cur since new funds are available
@@ -523,12 +523,12 @@ class DataParser:
         dividend_per_asset = row[5]
         month_asset_amounts = self.available_asset(asset_id, account)
         for (month,asset_amount) in month_asset_amounts:
-                self.data_cur.execute("INSERT OR IGNORE INTO month_data(month, account) VALUES(?,?)", (month, account))
-                self.data_cur.execute("UPDATE month_data SET capital = capital + ? WHERE month = ? AND account = ?", (asset_amount*dividend_per_asset, month, account))
+                self.data_cur.execute("INSERT OR IGNORE INTO cohort_data(month, account) VALUES(?,?)", (month, account))
+                self.data_cur.execute("UPDATE cohort_data SET capital = capital + ? WHERE month = ? AND account = ?", (asset_amount*dividend_per_asset, month, account))
                 remaining_amount -= asset_amount
         if remaining_amount > 0:
-            self.data_cur.execute("INSERT OR IGNORE INTO month_data(month, account) VALUES(?,?)", (dividend_month, account))
-            self.data_cur.execute("UPDATE month_data SET capital = capital + ? WHERE month = ? AND account = ?", (remaining_amount*dividend_per_asset, dividend_month, account))
+            self.data_cur.execute("INSERT OR IGNORE INTO cohort_data(month, account) VALUES(?,?)", (dividend_month, account))
+            self.data_cur.execute("UPDATE cohort_data SET capital = capital + ? WHERE month = ? AND account = ?", (remaining_amount*dividend_per_asset, dividend_month, account))
         # Reset transaction_cur since new funds are available
         self.transaction_cur.execute("UPDATE transactions SET processed = 1 WHERE rowid = ?",(row[-1],))
         self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, rowid ASC")
@@ -550,12 +550,12 @@ class DataParser:
         dividend_per_capital = remaining_amount / total_capital
         for (month, capital) in month_capital:
             amount_added = capital * dividend_per_capital
-            self.data_cur.execute("INSERT OR IGNORE INTO month_data(month, account) VALUES(?,?)", (month, account))
-            self.data_cur.execute("UPDATE month_data SET capital = capital + ? WHERE month = ? AND account = ?", (amount_added, month, account))
+            self.data_cur.execute("INSERT OR IGNORE INTO cohort_data(month, account) VALUES(?,?)", (month, account))
+            self.data_cur.execute("UPDATE cohort_data SET capital = capital + ? WHERE month = ? AND account = ?", (amount_added, month, account))
             remaining_amount -= amount_added
         if remaining_amount > 0:
-            self.data_cur.execute("INSERT OR IGNORE INTO month_data(month, account) VALUES(?,?)", (dividend_month, account))
-            self.data_cur.execute("UPDATE month_data SET capital = capital + ? WHERE month = ? AND account = ?", (remaining_amount, dividend_month, account))
+            self.data_cur.execute("INSERT OR IGNORE INTO cohort_data(month, account) VALUES(?,?)", (dividend_month, account))
+            self.data_cur.execute("UPDATE cohort_data SET capital = capital + ? WHERE month = ? AND account = ?", (remaining_amount, dividend_month, account))
         # Reset transaction_cur since new funds are available
         self.transaction_cur.execute("UPDATE transactions SET processed = 1 WHERE rowid = ?",(row[-1],))
         self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, rowid ASC")
@@ -583,7 +583,7 @@ class DataParser:
             while remaining_amount > 1e-4:
                 (oldest_available,capital) = month_capital[i]
                 month_amount = min(remaining_amount,capital)
-                self.data_cur.execute("UPDATE month_data SET capital = capital - ? WHERE month = ? AND account = ?", (month_amount, oldest_available, account))
+                self.data_cur.execute("UPDATE cohort_data SET capital = capital - ? WHERE month = ? AND account = ?", (month_amount, oldest_available, account))
                 
                 # Aggregate fee cash flow for the cohort in the transaction month
                 self.data_cur.execute("""
@@ -617,7 +617,7 @@ class DataParser:
             (asset_id,) = self.data_cur.execute("SELECT asset_id FROM assets WHERE asset = ?",(asset,)).fetchone()
             self.data_cur.execute("UPDATE assets SET asset = ?, amount = ? WHERE asset_id = ?",(self.listing_change["to_asset"],self.listing_change["to_asset_amount"],asset_id))
             change_factor = self.listing_change["to_asset_amount"]/amount
-            self.data_cur.execute("UPDATE month_assets SET amount = amount * ? WHERE asset_id = ?",(change_factor,asset_id))
+            self.data_cur.execute("UPDATE cohort_assets SET amount = amount * ? WHERE asset_id = ?",(change_factor,asset_id))
             self.transaction_cur.execute("UPDATE transactions SET processed = 1 WHERE rowid = ? OR rowid = ?",(row[-1],self.listing_change["to_rowid"],))
             self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, rowid ASC")
             self.listing_change = {"to_asset":None,"to_asset_amount":None,"to_rowid":None}
@@ -639,14 +639,14 @@ class DataParser:
         asset_id = self.data_cur.execute("SELECT asset_id FROM assets WHERE asset = ?",(asset,)).fetchone()[0]
         date = row[0]
         self.data_cur.execute("UPDATE assets SET latest_price = ?, latest_price_date = ? WHERE asset_id = ?", (price, date, asset_id))
-        self.data_cur.execute("INSERT OR IGNORE INTO month_assets(month,asset_id,account) VALUES (?,?,?)",(month,asset_id,account))
+        self.data_cur.execute("INSERT OR IGNORE INTO cohort_assets(month,asset_id,account) VALUES (?,?,?)",(month,asset_id,account))
         # Update average price and average purchase price
-        self.data_cur.execute("UPDATE month_assets SET average_price = (? * ? + amount * average_price) / (amount + ?) WHERE month = ? AND asset_id = ? AND account = ?", (amount, price, amount, month, asset_id, account))
-        self.data_cur.execute("UPDATE month_assets SET average_purchase_price = (? * ? + purchased_amount * average_purchase_price) / (purchased_amount + ?) WHERE month = ? AND asset_id = ? AND account = ?", (amount, price, amount, month, asset_id, account))
+        self.data_cur.execute("UPDATE cohort_assets SET average_price = (? * ? + amount * average_price) / (amount + ?) WHERE month = ? AND asset_id = ? AND account = ?", (amount, price, amount, month, asset_id, account))
+        self.data_cur.execute("UPDATE cohort_assets SET average_purchase_price = (? * ? + purchased_amount * average_purchase_price) / (purchased_amount + ?) WHERE month = ? AND asset_id = ? AND account = ?", (amount, price, amount, month, asset_id, account))
         # Update amount and purchased amount
-        self.data_cur.execute("UPDATE month_assets SET amount = amount + ? WHERE month = ? AND asset_id = ? AND account = ?",(amount,month,asset_id,account))
-        self.data_cur.execute("INSERT OR IGNORE INTO month_data(month, account) VALUES(?,?)", (month, account))
-        self.data_cur.execute("UPDATE month_data SET deposit = deposit + ?, active_base = active_base + ? WHERE month = ? AND account = ?", (amount*price, amount*price, month, account))
+        self.data_cur.execute("UPDATE cohort_assets SET amount = amount + ? WHERE month = ? AND asset_id = ? AND account = ?",(amount,month,asset_id,account))
+        self.data_cur.execute("INSERT OR IGNORE INTO cohort_data(month, account) VALUES(?,?)", (month, account))
+        self.data_cur.execute("UPDATE cohort_data SET deposit = deposit + ?, active_base = active_base + ? WHERE month = ? AND account = ?", (amount*price, amount*price, month, account))
         # Reset transaction_cur since new assets are available
         self.transaction_cur.execute("UPDATE transactions SET processed = 1 WHERE rowid = ?",(row[-1],))
         self.transaction_cur.execute("SELECT *,rowid FROM transactions WHERE processed == 0 ORDER BY date ASC, rowid ASC")
@@ -729,12 +729,12 @@ class DataParser:
                     r = month_amount / cv
                     r = min(r, 1.0)
                     self.data_cur.execute(
-                        "UPDATE month_data SET active_base = active_base * (1 - ?) WHERE month = ? AND account = ?",
+                        "UPDATE cohort_data SET active_base = active_base * (1 - ?) WHERE month = ? AND account = ?",
                         (r, oldest_available, out_account))
 
                 # Remove from OUT account
                 self.data_cur.execute(
-                    "UPDATE month_data SET capital = capital - ? WHERE month = ? AND account = ?",
+                    "UPDATE cohort_data SET capital = capital - ? WHERE month = ? AND account = ?",
                     (month_amount, oldest_available, out_account)
                 )
                 
@@ -752,11 +752,11 @@ class DataParser:
             in_transaction_month = self.allocate_to_month(in_date)
             for oldest_available, amount in allocations:
                 self.data_cur.execute(
-                    "INSERT OR IGNORE INTO month_data(month, account) VALUES(?,?)",
+                    "INSERT OR IGNORE INTO cohort_data(month, account) VALUES(?,?)",
                     (oldest_available, in_account)
                 )
                 self.data_cur.execute(
-                    "UPDATE month_data SET capital = capital + ?, active_base = active_base + ? WHERE month = ? AND account = ?",
+                    "UPDATE cohort_data SET capital = capital + ?, active_base = active_base + ? WHERE month = ? AND account = ?",
                     (amount, amount, oldest_available, in_account)
                 )
                 
@@ -815,7 +815,7 @@ class DataParser:
                 (oldest_available, amount) = month_asset_amounts[i]
                 month_amount = min(remaining_amount, amount)
                 # Just remove shares, no capital change
-                self.data_cur.execute("UPDATE month_assets SET amount = amount - ? WHERE month = ? AND asset_id = ? AND account = ?",
+                self.data_cur.execute("UPDATE cohort_assets SET amount = amount - ? WHERE month = ? AND asset_id = ? AND account = ?",
                                      (month_amount, oldest_available, asset_id, account))
                 remaining_amount -= month_amount
                 i += 1
@@ -887,7 +887,7 @@ class DataParser:
             #Calculate summary data and put it in asset table
             asset_ids = self.data_cur.execute("SELECT asset_id FROM assets").fetchall()
             for (id,) in asset_ids:
-                month_asset_data = self.data_cur.execute("SELECT amount, average_price, average_purchase_price, average_sale_price, purchased_amount, sold_amount FROM month_assets WHERE asset_id = ?",(id,)).fetchall()
+                month_asset_data = self.data_cur.execute("SELECT amount, average_price, average_purchase_price, average_sale_price, purchased_amount, sold_amount FROM cohort_assets WHERE asset_id = ?",(id,)).fetchall()
                 amount = 0
                 average_price = 0
                 average_purchase_price = 0

--- a/database_handler.py
+++ b/database_handler.py
@@ -79,7 +79,7 @@ class DatabaseHandler:
 
         cursor = self.conn.cursor()
 
-        # Enable foreign key support, used by month_assets table to reference assets and month_data
+        # Enable foreign key support, used by cohort_assets table to reference assets and cohort_data
         cursor.execute("PRAGMA foreign_keys = ON;")
 
         # transactions contains all raw transactions
@@ -98,9 +98,9 @@ class DatabaseHandler:
                 processed INT DEFAULT 0
                 )""")
 
-        # month_data contains the capital, deposits and withdrawals per account per month
+        # cohort_data contains the capital, deposits and withdrawals per account per month
         cursor.execute("""
-            CREATE TABLE IF NOT EXISTS month_data(
+            CREATE TABLE IF NOT EXISTS cohort_data(
                 month DATE NOT NULL,
                 account TEXT NOT NULL,
                 deposit REAL DEFAULT 0,
@@ -120,7 +120,7 @@ class DatabaseHandler:
                 account TEXT NOT NULL,
                 transaction_month DATE NOT NULL,
                 amount REAL DEFAULT 0,
-                FOREIGN KEY (cohort_month, account) REFERENCES month_data (month, account),
+                FOREIGN KEY (cohort_month, account) REFERENCES cohort_data (month, account),
                 PRIMARY KEY (cohort_month, account, transaction_month)
             );""")
 
@@ -140,9 +140,9 @@ class DatabaseHandler:
                 PRIMARY KEY(asset_id)
                 );""")
 
-        # month_assets contains the amount of each asset held, purchased and sold each month per account
+        # cohort_assets contains the amount of each asset held, purchased and sold each month per account
         cursor.execute("""
-            CREATE TABLE IF NOT EXISTS month_assets(
+            CREATE TABLE IF NOT EXISTS cohort_assets(
                 month DATE NOT NULL,
                 asset_id INTEGER NOT NULL,
                 account TEXT NOT NULL,
@@ -153,7 +153,7 @@ class DatabaseHandler:
                 purchased_amount REAL DEFAULT 0,
                 sold_amount REAL DEFAULT 0,
                 FOREIGN KEY (asset_id) REFERENCES assets (asset_id),
-                FOREIGN KEY (month, account) REFERENCES month_data (month, account),
+                FOREIGN KEY (month, account) REFERENCES cohort_data (month, account),
                 PRIMARY KEY(month, asset_id, account)
                 );""")
         
@@ -305,8 +305,8 @@ class DatabaseHandler:
 
         # Get total capital
         if "Capital" in stats:
-            # Take SUM of capital if there are any rows in month_data, otherwise set capital to 0
-            cursor.execute("SELECT CASE WHEN COUNT(*) > 0 THEN SUM(capital) ELSE 0 END FROM month_data")
+            # Take SUM of capital if there are any rows in cohort_data, otherwise set capital to 0
+            cursor.execute("SELECT CASE WHEN COUNT(*) > 0 THEN SUM(capital) ELSE 0 END FROM cohort_data")
             stat_value["Capital"] = cursor.fetchone()[0]
 
         # Get number of tables

--- a/test/test_per_account_asset_tracking.py
+++ b/test/test_per_account_asset_tracking.py
@@ -2,7 +2,7 @@
 Test per-account asset tracking implementation.
 
 These tests verify:
-1. Assets are tracked per account in month_assets table
+1. Assets are tracked per account in cohort_assets table
 2. Sales can only sell assets owned by the account
 3. Savings accounts don't get attributed assets they never purchased
 4. Assets are correctly associated with the purchasing account
@@ -112,10 +112,10 @@ def test_assets_correctly_attributed_to_purchasing_account(database_basic_two_ac
     """)
     purchases = cur.fetchall()
     
-    # Get asset holdings from month_assets
+    # Get asset holdings from cohort_assets
     cur.execute("""
         SELECT ma.account, a.asset, SUM(ma.amount) as held_amount
-        FROM month_assets ma
+        FROM cohort_assets ma
         JOIN assets a ON ma.asset_id = a.asset_id
         WHERE ma.amount > 0
         GROUP BY ma.account, a.asset
@@ -137,7 +137,7 @@ def test_assets_correctly_attributed_to_purchasing_account(database_basic_two_ac
 
 def test_assets_tracked_per_account(database_basic_two_accounts):
     """
-    Test that assets are tracked per account in month_assets.
+    Test that assets are tracked per account in cohort_assets.
     """
     db = database_basic_two_accounts
     db.connect()
@@ -147,9 +147,9 @@ def test_assets_tracked_per_account(database_basic_two_accounts):
     parser = DataParser(db)
     parser.process_transactions()
 
-    # Check month_assets table - should include account column
-    cur.execute("SELECT month, asset_id, account, amount FROM month_assets ORDER BY month, asset_id, account")
-    month_assets = cur.fetchall()
+    # Check cohort_assets table - should include account column
+    cur.execute("SELECT month, asset_id, account, amount FROM cohort_assets ORDER BY month, asset_id, account")
+    cohort_assets = cur.fetchall()
 
     # Get asset names for readability
     cur.execute("SELECT asset_id, asset FROM assets ORDER BY asset_id")
@@ -157,16 +157,16 @@ def test_assets_tracked_per_account(database_basic_two_accounts):
 
     # We have 2 assets purchased by different accounts
     # Should have 2 entries with account information
-    assert len(month_assets) == 2, "Should have 2 asset entries (one per asset per account)"
+    assert len(cohort_assets) == 2, "Should have 2 asset entries (one per asset per account)"
 
-    # Check that assets in month_assets include account info
-    for month, asset_id, account, amount in month_assets:
+    # Check that assets in cohort_assets include account info
+    for month, asset_id, account, amount in cohort_assets:
         asset_name = asset_map[asset_id]
-        print(f"Asset in month_assets: {month}, {asset_name}, Account: {account}, {amount} shares")
+        print(f"Asset in cohort_assets: {month}, {asset_name}, Account: {account}, {amount} shares")
 
     # Verify each asset is associated with the correct account
     asset_accounts = {}
-    for month, asset_id, account, amount in month_assets:
+    for month, asset_id, account, amount in cohort_assets:
         asset_name = asset_map[asset_id]
         asset_accounts[asset_name] = account
     
@@ -201,7 +201,7 @@ def test_accounts_only_hold_assets_they_purchased(database_savings_account_scena
     # Get all asset holdings by account
     cur.execute("""
         SELECT ma.account, a.asset, SUM(ma.amount) as held_amount
-        FROM month_assets ma
+        FROM cohort_assets ma
         JOIN assets a ON ma.asset_id = a.asset_id
         WHERE ma.amount > 0
         GROUP BY ma.account, a.asset

--- a/test/test_process_data_attribution.py
+++ b/test/test_process_data_attribution.py
@@ -34,7 +34,7 @@ def test_process_data__attribution_single_account(database_attribution_single_ac
     """
     Single account baseline: all gain correctly attributed to the deposit month.
 
-    Expected month_data:
+    Expected cohort_data:
       - One row: deposit=110, withdrawal=210, gain=100
       - No orphan rows (rows with withdrawal > 0 but deposit == 0)
     """
@@ -50,7 +50,7 @@ def test_process_data__attribution_single_account(database_attribution_single_ac
     cur = database_attribution_single_account.get_cursor()
 
     rows = cur.execute(
-        "SELECT month, account, deposit, capital, withdrawal FROM month_data ORDER BY month, account"
+        "SELECT month, account, deposit, capital, withdrawal FROM cohort_data ORDER BY month, account"
     ).fetchall()
 
     total_deposit = sum(r[2] for r in rows)
@@ -67,7 +67,7 @@ def test_process_data__attribution_two_accounts(database_attribution_two_account
     Two accounts: gain should be attributed to the original deposit month,
     regardless of the capital moving to a different account via internal transfer.
 
-    Expected month_data:
+    Expected cohort_data:
       - Total deposit = 110 SEK
       - Total withdrawal = 210 SEK
       - No orphan rows (rows with withdrawal > 0 but deposit == 0)
@@ -86,7 +86,7 @@ def test_process_data__attribution_two_accounts(database_attribution_two_account
     cur = database_attribution_two_accounts.get_cursor()
 
     rows = cur.execute(
-        "SELECT month, account, deposit, capital, withdrawal FROM month_data ORDER BY month, account"
+        "SELECT month, account, deposit, capital, withdrawal FROM cohort_data ORDER BY month, account"
     ).fetchall()
 
     total_deposit = sum(r[2] for r in rows)

--- a/test/test_process_data_deferral.py
+++ b/test/test_process_data_deferral.py
@@ -53,13 +53,13 @@ def test_process_data__transfer_deferral(database_transfer_deferral):
     cur = database_transfer_deferral.get_cursor()
 
     capital_1111 = cur.execute(
-        "SELECT SUM(capital) FROM month_data WHERE account = '1111'"
+        "SELECT SUM(capital) FROM cohort_data WHERE account = '1111'"
     ).fetchone()[0] or 0.0
     capital_2222 = cur.execute(
-        "SELECT SUM(capital) FROM month_data WHERE account = '2222'"
+        "SELECT SUM(capital) FROM cohort_data WHERE account = '2222'"
     ).fetchone()[0] or 0.0
     asset_amount = cur.execute(
-        "SELECT COALESCE(SUM(amount), 0) FROM month_assets"
+        "SELECT COALESCE(SUM(amount), 0) FROM cohort_assets"
     ).fetchone()[0]
 
     assert abs(capital_1111 - 25.0) < 0.01, f"Account 1111 capital should be 25, got {capital_1111}"
@@ -84,13 +84,13 @@ def test_process_data__transfer_proper_order(database_transfer_proper_order):
     cur = database_transfer_proper_order.get_cursor()
 
     capital_1111 = cur.execute(
-        "SELECT SUM(capital) FROM month_data WHERE account = '1111'"
+        "SELECT SUM(capital) FROM cohort_data WHERE account = '1111'"
     ).fetchone()[0] or 0.0
     capital_2222 = cur.execute(
-        "SELECT SUM(capital) FROM month_data WHERE account = '2222'"
+        "SELECT SUM(capital) FROM cohort_data WHERE account = '2222'"
     ).fetchone()[0] or 0.0
     asset_amount = cur.execute(
-        "SELECT COALESCE(SUM(amount), 0) FROM month_assets"
+        "SELECT COALESCE(SUM(amount), 0) FROM cohort_assets"
     ).fetchone()[0]
 
     assert abs(capital_1111 - 25.0) < 0.01, f"Account 1111 capital should be 25, got {capital_1111}"

--- a/test/test_twrr.py
+++ b/test/test_twrr.py
@@ -40,7 +40,7 @@ def test_twrr_active_base_tracking(twrr_scenario_db):
     cur = twrr_scenario_db.get_cursor()
 
     rows = cur.execute(
-        "SELECT month, deposit, active_base, capital FROM month_data ORDER BY month"
+        "SELECT month, deposit, active_base, capital FROM cohort_data ORDER BY month"
     ).fetchall()
 
     assert len(rows) == 1
@@ -59,7 +59,7 @@ def test_twrr_closed_return_snapshot(twrr_scenario_db):
     cur = twrr_scenario_db.get_cursor()
     
     # closed_return should be NULL since position is still open (50 shares remain)
-    row = cur.execute("SELECT closed_return FROM month_data").fetchone()
+    row = cur.execute("SELECT closed_return FROM cohort_data").fetchone()
     assert row[0] is None, "Open position should not have closed_return"
 
 
@@ -97,7 +97,7 @@ def test_twrr_closed_position_has_return(twrr_closed_db):
     twrr_closed_db.connect()
     cur = twrr_closed_db.get_cursor()
     
-    row = cur.execute("SELECT closed_return FROM month_data").fetchone()
+    row = cur.execute("SELECT closed_return FROM cohort_data").fetchone()
     assert row[0] is not None, "Closed position should have closed_return"
     assert abs(row[0] - 2.0) < 0.1, f"Expected closed_return ~2.0, got {row[0]}"
     


### PR DESCRIPTION
Resolves #34.

This PR addresses the ambiguous naming conventions in the database schema and related Python code. 

Changes made:
- Renamed `month_data` to `cohort_data` to accurately reflect investment cohorts grouped by month-end dates.
- Renamed `month_assets` to `cohort_assets` to reflect cohort-level asset holdings.
- Renamed `account_month_stats` to `account_cohort_stats` to reflect cohort-level statistics.

The `cohort_cash_flows` and `account_year_stats` tables were kept as is, as they were already correctly named.

All tests continue to pass and no functional changes were made.
