### PR TITLE
Add transaction date range to status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ python cli.py import data/your_transactions.csv
 # 2. Get statistics with automatic price updates
 python cli.py stats --update-prices auto --period year --deposits all
 
-# 3. Check system status anytime
+# 3. Check system status anytime (includes transaction date range)
 python cli.py status
 
 # 4. (Optional) Set default accounts for filtering
@@ -76,7 +76,7 @@ python cli.py import data/transactions.csv
 # Show statistics with smart updates (auto-updates prices if stale)
 python cli.py stats --update-prices auto --period year --deposits all
 
-# Check system status (transactions, prices, metadata)
+# Check system status (transactions, prices, metadata, date range)
 python cli.py status
 
 # Reset database state (mark all transactions as unprocessed)
@@ -242,6 +242,18 @@ The unified CLI provides all functionality in a streamlined interface:
 5. (Optional) Set account nicknames: `python cli.py settings account-nickname 1234567 "Savings"`
 6. View account summaries: `python cli.py accounts --update-prices auto`
 7. Check system status: `python cli.py status`
+
+**Status output includes transaction date range:**
+```
+=== Investment Tracker Status ===
+Database:
+ Transactions: 930
+ Processed: 930
+ Unprocessed: 0
+ Date range: 2017-12-01 to 2026-06-08
+Assets: 96
+Capital: 47431 SEK
+```
 
 **Advanced usage with account filtering:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This project is a work in progress and will be updated as I go along.
     - **Period-specific**: Track performance of investments made in each month/year
     - **Accumulated**: See total portfolio value over time with assets carried forward
 - **Account filtering**: View statistics for any combination of accounts with full accumulated history support
+- **System status**: Check database statistics, price freshness, and transaction date range
 
 ## Installation
 
@@ -48,7 +49,7 @@ python cli.py import data/your_transactions.csv
 # 2. Get statistics with automatic price updates
 python cli.py stats --update-prices auto --period year --deposits all
 
-# 3. Check system status anytime (includes transaction date range)
+# 3. Check system status anytime
 python cli.py status
 
 # 4. (Optional) Set default accounts for filtering
@@ -76,7 +77,7 @@ python cli.py import data/transactions.csv
 # Show statistics with smart updates (auto-updates prices if stale)
 python cli.py stats --update-prices auto --period year --deposits all
 
-# Check system status (transactions, prices, metadata, date range)
+# Check system status (transactions, prices, metadata)
 python cli.py status
 
 # Reset database state (mark all transactions as unprocessed)
@@ -242,18 +243,6 @@ The unified CLI provides all functionality in a streamlined interface:
 5. (Optional) Set account nicknames: `python cli.py settings account-nickname 1234567 "Savings"`
 6. View account summaries: `python cli.py accounts --update-prices auto`
 7. Check system status: `python cli.py status`
-
-**Status output includes transaction date range:**
-```
-=== Investment Tracker Status ===
-Database:
- Transactions: 930
- Processed: 930
- Unprocessed: 0
- Date range: 2017-12-01 to 2026-06-08
-Assets: 96
-Capital: 47431 SEK
-```
 
 **Advanced usage with account filtering:**
 ```bash

--- a/SKILL.md
+++ b/SKILL.md
@@ -49,7 +49,7 @@ The skill provides logic. Your data stays private and portable.
 | `python scripts/cli.py stats` | Show performance stats |
 | `python scripts/cli.py stats --update-prices auto` | Update prices, then show stats |
 | `python scripts/cli.py accounts` | Show account summaries |
-| `python scripts/cli.py status` | Check system status |
+| `python scripts/cli.py status` | Check system status (incl. transaction date range) |
 | `python scripts/cli.py reset --confirm` | Clear database (DESTRUCTIVE) |
 
 All commands accept:

--- a/SKILL.md
+++ b/SKILL.md
@@ -49,7 +49,7 @@ The skill provides logic. Your data stays private and portable.
 | `python scripts/cli.py stats` | Show performance stats |
 | `python scripts/cli.py stats --update-prices auto` | Update prices, then show stats |
 | `python scripts/cli.py accounts` | Show account summaries |
-| `python scripts/cli.py status` | Check system status (incl. transaction date range) |
+| `python scripts/cli.py status` | Check system status (database stats, prices, and date range) |
 | `python scripts/cli.py reset --confirm` | Clear database (DESTRUCTIVE) |
 
 All commands accept:

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -269,6 +269,12 @@ def status(args):
     print(f"  Assets: {db_stats.get('Assets', 0)}")
     print(f"  Capital: {db_stats.get('Capital', 0):.0f} SEK")
     
+    min_date, max_date = db.get_date_range()
+    if min_date and max_date:
+        print(f"  Date range: {min_date} to {max_date}")
+    elif min_date or max_date:
+        print(f"  Date range: {min_date or max_date}")
+    
     # Price freshness
     fresh, oldest_date = prices_are_fresh(db)
     price_status = "Fresh" if fresh else "Stale"

--- a/scripts/database_handler.py
+++ b/scripts/database_handler.py
@@ -461,6 +461,21 @@ class DatabaseHandler:
         cursor.execute("SELECT account_id, nickname FROM accounts WHERE nickname IS NOT NULL")
         return dict(cursor.fetchall())
 
+    def get_date_range(self) -> tuple:
+        """
+        Get the minimum and maximum transaction dates.
+        
+        Returns:
+        tuple: (min_date, max_date) as strings in YYYY-MM-DD format, or (None, None) if no transactions
+        """
+        if not self.conn:
+            raise Exception("Database connection not established.")
+        
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT MIN(date), MAX(date) FROM transactions")
+        result = cursor.fetchone()
+        return (result[0], result[1]) if result else (None, None)
+
 
 # Example Usage
 if __name__ == "__main__":


### PR DESCRIPTION
Implements the feature request from issue #55.

**Changes:**
- Added `get_date_range()` method to `DatabaseHandler` in `scripts/database_handler.py` that returns `(min_date, max_date)` from the `transactions` table.
- Updated the `status` command in `scripts/cli.py` to display the date range under the Database section.
- Added documentation for the status command feature under the Features list in `README.md` and updated command details in `SKILL.md`.

All 62 existing tests pass.
